### PR TITLE
Display all known 342 characters.

### DIFF
--- a/340/tst342.108
+++ b/340/tst342.108
@@ -1,0 +1,80 @@
+	TITLE TST342 - Type 342 character set test.
+
+;Test all known Type 342 character codes.
+;Runs on ITS and out of timesharing.
+;Works on both PDP-6 and PDP-10.  
+
+A=1
+BLKOP=16
+
+APR==0
+PI==4
+DIS==130
+DISCHN==1
+
+LOC 41
+	JRST NTS
+
+LOC 40+2*DISCHN
+	BLKO DIS,BLKOP
+	JSR RECYC
+
+LOC 100
+START:	.DSTART [-DLEN,,DLIST-1]	;Go through 41 if not timesharing.
+	JFCL
+	 .HANG				;Hang here forever.
+
+NTS:	CONO APR,675550			;Reset processor.
+	CONO PI,10400			;Reset and deactivate PI.
+	JRS RECYC       		;Reset and start display.
+	CONO PI,2200+<200_-DISCHN>	;Activate PI and turn on channel.
+	JRST .
+	
+RECYC:	0
+	MOVE BLKOP,[-DLEN,,DLIST-1]     ;Reset BLKO pointer.
+	CONO DIS,100+DISCHN		;Reset 340, assign channel.
+	JRST 12,@RECYC
+
+POINT==020000
+CHARA==060000
+VERTI==200000
+
+	.BYTE 18.
+DLIST:	POINT+<5_4>+17			;Set intensity and scaling.
+	POINT+0.			;Set horizontal position.
+	CHARA+VERTI+1000.		;Set vertical position.
+
+	;Shift in character set.
+	.BYTE 6
+	REPEAT 20,.RPCNT		;0-17: Blob, ABCDEFGHIJKLMNO.
+	34 ? 33				;CR LF
+	REPEAT 33-20,20+.RPCNT		;20-32: PQRSTUVWXYZ.
+	34 ? 33				;CR LF
+	REPEAT 60-40,40+.RPCNT		;40-57: Space, !"#$%&'()*+,-./.
+	34 ? 33				;CR LF
+	REPEAT 100-60,60+.RPCNT		;60-77: 0123456789:;<=>?.
+	34 ? 33				;CR LF
+
+	;Shift out character set.
+	36				;Shift out.
+	REPEAT 20,.RPCNT		;0-17: ?abcdefghijklmno.
+	34 ? 33				;CR LF.
+	REPEAT 33-20,20+.RPCNT		;20-32: pqrstuvwxyz.
+	34 ? 33				;CR LF
+	REPEAT 20,40+.RPCNT		;40-57: Space, ??~??, arrows, \[]{}?.
+	34 ? 33				;CR LF
+	REPEAT 66-60,60+.RPCNT		;60-65: _??|???.
+	40 ? 66				;66: overstriking `.
+	40 ? 67				;67: overstriking ^.
+	70 ? 71				;70-71: ?, cursor?
+	34 ? 33				;CR LF
+	43 ? 72 ? 60			;72: backspace.
+	73 ? 1 ? 77 ? 2			;73, 77: subscript and superscript.
+	77 ? 3 ? 73 ? 4
+					;74-76: unknown.
+	40 ? 40				;Padding.
+	.BYTE
+	
+DLEN==.-DLIST
+
+END START


### PR DESCRIPTION
Like this, when running the KA10:  
![tst342](https://user-images.githubusercontent.com/775050/58751292-0f200780-849d-11e9-87b2-023300a05d98.png)
